### PR TITLE
Fix Consable#flatten for included other instance

### DIFF
--- a/lib/immutable/consable.rb
+++ b/lib/immutable/consable.rb
@@ -180,7 +180,7 @@ module Immutable
     #
     # @return [Consable] the concatenated +Consable+ object.
     def flatten
-      foldr(empty) { |x, xs| x + xs }
+      flat_map { |x| x.respond_to?(:to_list) ? x.to_list : Cons(x, empty) }
     end
 
     alias concat flatten

--- a/test/immutable/test_list.rb
+++ b/test/immutable/test_list.rb
@@ -184,6 +184,10 @@ module Immutable
       assert_equal(List[List[1]], List[List[List[1]]].flatten)
       assert_equal(List[1, 2, 3], List[List[1, 2], List[3]].flatten)
       assert_equal(List[1, 2, 3], List[List[1], List[2], List[3]].flatten)
+      assert_equal(List[1, 2, 3], List[List[1], 2, List[3]].flatten)
+      assert_equal(List[1, [2], 3], List[List[1], [2], List[3]].flatten)
+      obj = Object.new
+      assert_equal(List[obj, 'str', obj], List[obj, 'str', obj].flatten)
     end
 
     def test_map


### PR DESCRIPTION
Consable以外のインスタンスを含んだ際のflattenで例外を吐くよりも、まとめて平らになったほうが嬉しいと感じました。
ご検討下さい。
