### PR TITLE
Map get API for more flendly with Hash

### DIFF
--- a/lib/immutable/map.rb
+++ b/lib/immutable/map.rb
@@ -66,6 +66,22 @@ module Immutable
       end
     end
 
+    # @return [Boolean]
+    def ==(x)
+      x.is_a?(self.class) && (to_h == x.to_h)
+    end
+
+    alias === ==
+
+    def eql?(x)
+      x.is_a?(self.class) && to_h.eql?(x.to_h)
+    end
+
+    # @return [Integer]
+    def hash
+      to_h.hash
+    end
+
     # @return [String]
     def inspect
       "Map[" + foldr_with_key("") { |k, v, s|

--- a/lib/immutable/map.rb
+++ b/lib/immutable/map.rb
@@ -81,8 +81,14 @@ module Immutable
     alias to_s inspect
 
     # Calls +block+ once for each key/value in +self+.
+    # @yield [key, element]
+    # @yieldreturn [self]
+    # @return [self]
     def each(&block)
+      return to_enum(__callee__) unless block_given?
+
       foldl_with_key(nil) { |x, k, v| yield([k, v]) }
+      self
     end
 
     alias each_pair each

--- a/lib/immutable/map.rb
+++ b/lib/immutable/map.rb
@@ -85,6 +85,8 @@ module Immutable
       foldl_with_key(nil) { |x, k, v| yield([k, v]) }
     end
 
+    alias each_pair each
+
     # Folds the values in +self+ from right to left.
     def foldr(e)
       foldr_with_key(e) { |k, v, x| yield(v, x) }

--- a/lib/immutable/map.rb
+++ b/lib/immutable/map.rb
@@ -113,6 +113,11 @@ module Immutable
       foldr_with_key(List[]) { |k, v, xs| Cons[yield(k, v), xs] }
     end
 
+    # @return [Hash]
+    def to_h
+      Hash[each_pair.to_a]
+    end
+
     # :nodoc:
     Leaf = Map.new
 

--- a/test/immutable/test_map.rb
+++ b/test/immutable/test_map.rb
@@ -67,6 +67,16 @@ module Immutable
       assert_equal([[:a, 1], [:b, 2], [:c, 3]], a)
     end
 
+    def test_each_pair
+      a = []
+      Map[].each_pair { |x| a << x }
+      assert_equal([], a)
+
+      a = []
+      Map[a: 1, c: 3, b: 2].each_pair { |x| a << x }
+      assert_equal([[:a, 1], [:b, 2], [:c, 3]], a)
+    end
+
     def test_foldr
       xs = Map[].foldr(List[]) { |v, ys| Cons[v, ys] }
       assert_equal(List[], xs)

--- a/test/immutable/test_map.rb
+++ b/test/immutable/test_map.rb
@@ -57,6 +57,43 @@ module Immutable
       end
     end
 
+    def test_eq
+      assert_same(true, Map[] == Map[])
+      assert_same(true, Map[a: 1, c: 3, b: 2] == Map[c: 3, b: 2, a: 1])
+      assert_same(false, Map[] == {})
+      assert_same(false, Map[a: 1, c: 3, b: 2] == Map[c: 3, b: 2, a: 1, A: 1])
+      assert_same(false, Map[a: 1, c: 3, b: 2] == Map[c: 3, b: 2, a: '1'])
+      assert_same(false, Map[a: 1, c: 3, b: 2] == Map[c: 3, b: 2])
+    end
+
+    def test_case_equal
+      assert_same(true, Map[] === Map[])
+      assert_same(true, Map[a: 1, c: 3, b: 2] === Map[c: 3, b: 2, a: 1])
+      assert_same(false, Map[] === {})
+      assert_same(false, Map[a: 1, c: 3, b: 2] === Map[c: 3, b: 2, a: 1, A: 1])
+      assert_same(false, Map[a: 1, c: 3, b: 2] === Map[c: 3, b: 2, a: '1'])
+      assert_same(false, Map[a: 1, c: 3, b: 2] === Map[c: 3, b: 2])
+    end
+
+    def test_eql
+      assert_same(true, Map[] == Map[])
+      assert_same(true, Map[a: 1, c: 3, b: 2].eql?(Map[c: 3, b: 2, a: 1]))
+      assert_same(false, Map[].eql?({}))
+      assert_same(false, Map[a: 1, c: 3, b: 2].eql?(Map[c: 3, b: 2, a: 1, A: 1]))
+      assert_same(false, Map[a: 1, c: 3, b: 2].eql?(Map[c: 3, b: 2, a: '1']))
+      assert_same(false, Map[a: 1, c: 3, b: 2].eql?(Map[c: 3, b: 2]))
+    end
+
+    def test_hash_key
+      map1 = Map[1 => 1, 2 => 3]
+      map2 = Map[1 => 1, 2 => 3]
+      map3 = Map[1 => 1, 2.0 => 3]
+      hash = {map1 => true}
+      assert_same(true, hash.has_key?(map1))
+      assert_same(true, hash.has_key?(map2))
+      assert_same(false, hash.has_key?(map3))
+    end
+
     def test_each
       a = []
       map = Map[]

--- a/test/immutable/test_map.rb
+++ b/test/immutable/test_map.rb
@@ -105,6 +105,11 @@ module Immutable
       end
     end
 
+    def test_to_h
+      assert_equal({}, Map[].to_h)
+      assert_equal({a: 1, c: 3, b: 2}, Map[a: 1, c: 3, b: 2].to_h)
+    end
+
     def test_foldr
       xs = Map[].foldr(List[]) { |v, ys| Cons[v, ys] }
       assert_equal(List[], xs)

--- a/test/immutable/test_map.rb
+++ b/test/immutable/test_map.rb
@@ -59,22 +59,50 @@ module Immutable
 
     def test_each
       a = []
-      Map[].each { |x| a << x }
+      map = Map[]
+      ret = map.each { |x| a << x }
       assert_equal([], a)
+      assert_same(ret, map)
+      enum = map.each
+      assert_instance_of(Enumerator, enum)
 
       a = []
-      Map[a: 1, c: 3, b: 2].each { |x| a << x }
+      map = Map[a: 1, c: 3, b: 2]
+      ret = map.each { |x| a << x }
       assert_equal([[:a, 1], [:b, 2], [:c, 3]], a)
+      assert_same(ret, map)
+      enum = map.each
+      assert_instance_of(Enumerator, enum)
+      assert_equal([:a, 1], enum.next)
+      assert_equal([:b, 2], enum.next)
+      assert_equal([:c, 3], enum.next)
+      assert_raise(StopIteration) do
+        enum.next
+      end
     end
 
     def test_each_pair
       a = []
-      Map[].each_pair { |x| a << x }
+      map = Map[]
+      ret = map.each_pair { |x| a << x }
       assert_equal([], a)
+      assert_same(ret, map)
+      enum = map.each_pair
+      assert_instance_of(Enumerator, enum)
 
       a = []
-      Map[a: 1, c: 3, b: 2].each_pair { |x| a << x }
+      map = Map[a: 1, c: 3, b: 2]
+      ret = map.each_pair { |x| a << x }
       assert_equal([[:a, 1], [:b, 2], [:c, 3]], a)
+      assert_same(ret, map)
+      enum = map.each_pair
+      assert_instance_of(Enumerator, enum)
+      assert_equal([:a, 1], enum.next)
+      assert_equal([:b, 2], enum.next)
+      assert_equal([:c, 3], enum.next)
+      assert_raise(StopIteration) do
+        enum.next
+      end
     end
 
     def test_foldr


### PR DESCRIPTION
Hashに近い感覚で使いやすくなるよう、いくつかのメソッドを追加しました。

また、Map.#[]の受け取ったハッシュのキーによっては、ペアが消えたり例外が出たため、これを調整しています。

```ruby
Hash[{2.0 => 3, 2 => 5}]  #=> {2.0=>3, 2=>5}
Map[{2.0 => 3, 2 => 5}]   #=> Map[2 => 5]

Hash[{a: 1, 2.0 => 3}]    #=> {:a=>1, 2.0=>3}
Map[{a: 1, 2.0 => 3}]     #=> NoMethodError: undefined method `<' for nil:NilClass
```